### PR TITLE
add http req to addinvoice

### DIFF
--- a/ginlsat/ginlsat.go
+++ b/ginlsat/ginlsat.go
@@ -114,7 +114,7 @@ func (lsatmiddleware *GinLsatMiddleware) Handler(c *gin.Context) {
 		LNClientConn := &ln.LNClientConn{
 			LNClient: lsatmiddleware.LNClient,
 		}
-		invoice, paymentHash, err := LNClientConn.GenerateInvoice(ctx, lnInvoice)
+		invoice, paymentHash, err := LNClientConn.GenerateInvoice(ctx, lnInvoice, c.Request)
 		if err != nil {
 			c.Error(err)
 			c.Set("LSAT", &LsatInfo{

--- a/ginlsat_test.go
+++ b/ginlsat_test.go
@@ -104,7 +104,6 @@ func TestLsatWithLNURLConfig(t *testing.T) {
 			Address: os.Getenv("LNURL_ADDRESS"),
 		},
 	}
-	assert.NoError(t, err)
 	fr := &FiatRateConfig{
 		Currency: "USD",
 		Amount:   0.01,
@@ -168,7 +167,6 @@ func TestLsatWithLNDConfig(t *testing.T) {
 			MacaroonHex: os.Getenv("MACAROON_HEX"),
 		},
 	}
-	assert.NoError(t, err)
 	fr := &FiatRateConfig{
 		Currency: "USD",
 		Amount:   0.01,

--- a/ln/lnclient.go
+++ b/ln/lnclient.go
@@ -2,6 +2,7 @@ package ln
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -14,15 +15,15 @@ type LNClientConfig struct {
 	LNURLConfig  LNURLoptions
 }
 type LNClient interface {
-	AddInvoice(ctx context.Context, req *lnrpc.Invoice, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error)
+	AddInvoice(ctx context.Context, lnReq *lnrpc.Invoice, httpReq *http.Request, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error)
 }
 
 type LNClientConn struct {
 	LNClient LNClient
 }
 
-func (lnClientConn *LNClientConn) GenerateInvoice(ctx context.Context, lnInvoice lnrpc.Invoice) (string, lntypes.Hash, error) {
-	lnClientInvoice, err := lnClientConn.LNClient.AddInvoice(ctx, &lnInvoice)
+func (lnClientConn *LNClientConn) GenerateInvoice(ctx context.Context, lnInvoice lnrpc.Invoice, httpReq *http.Request) (string, lntypes.Hash, error) {
+	lnClientInvoice, err := lnClientConn.LNClient.AddInvoice(ctx, &lnInvoice, httpReq)
 	if err != nil {
 		return "", lntypes.Hash{}, err
 	}

--- a/ln/lnd.go
+++ b/ln/lnd.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -90,6 +91,6 @@ func NewLNDclient(lndOptions LNDoptions) (result *LNDWrapper, err error) {
 	}, nil
 }
 
-func (wrapper *LNDWrapper) AddInvoice(ctx context.Context, req *lnrpc.Invoice, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error) {
+func (wrapper *LNDWrapper) AddInvoice(ctx context.Context, req *lnrpc.Invoice, httpReq *http.Request, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error) {
 	return wrapper.client.AddInvoice(ctx, req, options...)
 }

--- a/ln/lnurl.go
+++ b/ln/lnurl.go
@@ -63,7 +63,7 @@ func NewLNURLClient(lnurlOptions LNURLoptions) (*LnAddressUrlResJson, error) {
 	return lnAddressUrlRes, nil
 }
 
-func (lnAddressUrlResJson *LnAddressUrlResJson) AddInvoice(ctx context.Context, lnInvoice *lnrpc.Invoice, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error) {
+func (lnAddressUrlResJson *LnAddressUrlResJson) AddInvoice(ctx context.Context, lnInvoice *lnrpc.Invoice, httpReq *http.Request, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error) {
 	callbackUrl := fmt.Sprintf("%s?amount=%d", lnAddressUrlResJson.Callback, MSAT_PER_SAT*lnInvoice.Value)
 	callbackUrlResBody, err := DoGetRequest(callbackUrl)
 	if err != nil {


### PR DESCRIPTION
This gives developers more flexibility when implementing the LNClient interface. Now they can implement a dynamic LN Address based on the data in the http request.