### PR TITLE
fixes bug in LSAT verification logic

### DIFF
--- a/ginlsat/ginlsat.go
+++ b/ginlsat/ginlsat.go
@@ -94,7 +94,7 @@ func (lsatmiddleware *GinLsatMiddleware) Handler(c *gin.Context) {
 	if err != nil {
 		// No Authorization present, check if client supports LSAT
 		acceptLsatField := c.Request.Header.Get("Accept")
-		if strings.Contains(acceptLsatField, "application/vnd.lsat.v1.full") {
+		if strings.Contains(acceptLsatField, LSAT_HEADER) {
 			lsatmiddleware.SetLSATHeader(c)
 			return
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,21 +11,25 @@ import (
 	"gopkg.in/macaroon.v2"
 )
 
-func ParseLsatHeader(authField []string) (*macaroon.Macaroon, lntypes.Preimage, error) {
+func ParseLsatHeader(authField string) (*macaroon.Macaroon, lntypes.Preimage, error) {
 	// A typical authField
 	// Authorization: LSAT AGIAJEemVQUTEyNCR0exk7ek90Cg==:1234abcd1234abcd1234abcd
 	if len(authField) == 0 {
 		return nil, lntypes.Preimage{}, fmt.Errorf("Authorization Field not present")
 	}
-	authFieldString := authField[0]
 	// Trim leading and trailing spaces
-	authFieldString = strings.TrimSpace(authFieldString)
-	if len(authFieldString) == 0 {
+	authField = strings.TrimSpace(authField)
+	if len(authField) == 0 {
 		return nil, lntypes.Preimage{}, fmt.Errorf("LSAT Header is not present")
 	}
-	token := strings.Split(authFieldString, " ")[1]
-	macaroonString := strings.TrimSpace(strings.Split(token, ":")[0])
-	preimageString := strings.TrimSpace(strings.Split(token, ":")[1])
+	// Trim LSAT prefix
+	token := strings.TrimPrefix(authField, "LSAT ")
+	splitted := strings.Split(token, ":")
+	if len(splitted) != 2 {
+		return nil, lntypes.Preimage{}, fmt.Errorf("LSAT does not have the right format: %s", authField)
+	}
+	macaroonString := strings.TrimSpace(splitted[0])
+	preimageString := strings.TrimSpace(splitted[1])
 
 	mac, err := GetMacaroonFromString(macaroonString)
 	if err != nil {


### PR DESCRIPTION
The LSAT middleware logic had a critical bug. Paid content was released when there [_was an error_](https://github.com/getAlby/gin-lsat/blob/6016b32dd596f795f00930aa1dbd24ddc6a87f88/ginlsat/ginlsat.go#L102) verifying the LSAT header, instead of when there was **no** error.

This commit fixes the bug and also cleans up some if / else logic: it is generally a bad idea to have else blocks, as they tend to make things too complex. Only use `if` and do an early return if necessary. Also _always_ use the form `if err != nil`, you should almost _never_ use `if err == nil`.

Tests did not catch this and are now failing because the `TEST_MACAROON` and `TEST_PREIMAGE` environment variables were actually invalid as well. So the unit tests should either check that no paid content is released using an invalid macaroon / preimage pair, or these variables should be updated so they are valid.